### PR TITLE
fall back to command line arguments if default config not found

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -73,9 +74,11 @@ func newConfiguration(flags *pflag.FlagSet) (*Configuration, error) {
 
 	cfile, _ := flags.GetString("config")
 	if cfile != "" {
-		v.SetConfigFile(cfile)
-		if err := v.ReadInConfig(); err != nil {
-			return nil, err
+		if _, err := os.Stat(cfile); !os.IsNotExist(err) {
+			v.SetConfigFile(cfile)
+			if err := v.ReadInConfig(); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const version = "0.4.0"
+const version = "0.5.1"
 
 var (
 	showHelp    = pflag.BoolP("help", "h", false, "Show usage")
@@ -135,7 +135,17 @@ func main() {
 		os.Exit(0)
 	}
 
-	config, err := newConfiguration(pflag.CommandLine)
+	var flags *pflag.FlagSet
+	flags = pflag.CommandLine
+
+	if flags.Changed("config") {
+		if _, err := os.Stat(*configName); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Configuration file does not exist:%s\n", *configName)
+			os.Exit(4)
+		}
+	}
+
+	config, err := newConfiguration(flags)
 	if err != nil {
 		log.Errorln(err)
 		os.Exit(3)


### PR DESCRIPTION
If the file in the path for the default configuration
is missing, fall back to using command line arguments and
environmental variables.
If the config file is given as a command line argument and missing
though, return an error.

This closes #2 